### PR TITLE
Add project approval functionality back

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -173,6 +173,44 @@ export class QTOApiClient {
       return []; // Return empty array on error
     }
   }
+
+  /**
+   * Approve project elements
+   * @param projectName - The name of the project to approve
+   * @returns Response with operation status
+   */
+  async approveProjectElements(
+    projectName: string
+  ): Promise<{ status: string; message: string; project: string }> {
+    // Ensure project name is URL encoded
+    const encodedProjectName = encodeURIComponent(projectName);
+    const endpoint = `/projects/${encodedProjectName}/approve/`;
+    try {
+      console.log(`Approving elements for project: ${projectName}`);
+      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Failed to approve project: ${response.statusText} - ${errorText}`
+        );
+      }
+
+      const result = await response.json();
+      console.log(`Successfully approved elements for project ${projectName}`);
+      return result;
+    } catch (error) {
+      console.error(
+        `Error approving elements for project '${projectName}': ${error}`
+      );
+      throw error;
+    }
+  }
 }
 
 // Create and export a default instance

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -198,14 +198,32 @@ const MainPage = () => {
   };
 
   const sendQtoToDatabase = async () => {
-    console.warn("sendQtoToDatabase needs refactoring or removal.");
     setIsPreviewDialogSending(true);
-    setKafkaError(
-      "Manual sending function needs refactoring for new workflow."
-    );
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    setIsPreviewDialogSending(false);
-    setPreviewDialogOpen(false);
+    setKafkaSuccess(null);
+    setKafkaError(null);
+
+    try {
+      if (!selectedProject) {
+        throw new Error("No project selected");
+      }
+
+      // Call the approve endpoint
+      await apiClient.approveProjectElements(selectedProject);
+
+      // Set success and close dialog
+      setKafkaSuccess(true);
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // Brief delay
+      setPreviewDialogOpen(false);
+    } catch (error) {
+      console.error("Error approving elements:", error);
+      setKafkaError(
+        `Failed to approve elements: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    } finally {
+      setIsPreviewDialogSending(false);
+    }
   };
 
   const handleCloseConfirmDialog = () => {
@@ -213,10 +231,8 @@ const MainPage = () => {
   };
 
   const handleOpenPreviewDialog = () => {
-    console.log("Preview/Send button clicked - functionality needs review.");
-    setKafkaError(
-      "Manual sending function needs refactoring for new workflow."
-    );
+    // Open the preview dialog
+    setPreviewDialogOpen(true);
   };
 
   const handleClosePreviewDialog = () => {

--- a/src/components/QtoPreviewDialog.tsx
+++ b/src/components/QtoPreviewDialog.tsx
@@ -14,12 +14,23 @@ import {
   TableHead,
   TableRow,
   Paper,
+  Box,
+  Chip,
 } from "@mui/material";
+
+// Type colors for the legend - more subtle palette
+const TYPE_COLORS = {
+  typeName: "#81c784", // Lighter green
+  instanceName: "#90caf9", // Lighter blue
+  ifcClass: "#ffcc80", // Lighter orange
+};
 
 // Interface for the elements passed from MainPage
 interface IfcElement {
   id: string; // Needed to check against editedElements keys
   type_name?: string | null;
+  name?: string | null;
+  type?: string | null;
 }
 
 // Interface matching the structure of the editedElements map from useElementEditing
@@ -44,6 +55,7 @@ interface QtoPreviewDialogProps {
 // Interface for the calculated summary data structure
 interface TypeSummary {
   typeName: string;
+  nameSource: "typeName" | "instanceName" | "ifcClass" | "unknown";
   totalCount: number;
   editedCount: number;
 }
@@ -62,15 +74,52 @@ export const QtoPreviewDialog: React.FC<QtoPreviewDialogProps> = ({
   const summaryData: TypeSummary[] = useMemo(() => {
     const summaryMap: Record<
       string,
-      { totalCount: number; editedCount: number }
+      {
+        totalCount: number;
+        editedCount: number;
+        nameSource: "typeName" | "instanceName" | "ifcClass" | "unknown";
+      }
     > = {};
 
     ifcElements.forEach((element) => {
-      const typeName = element.type_name || "Unbekannter Typ"; // Use a fallback for missing type names
+      // Implement fallback hierarchy for type name:
+      // 1. Use type_name if available
+      // 2. Fallback to element name if type_name is missing
+      // 3. Fallback to element type (IFC class) if both are missing
+      // 4. Last resort - use "Unbekannter Typ" only if all above are missing
+      let typeName = element.type_name;
+      let nameSource: "typeName" | "instanceName" | "ifcClass" | "unknown" =
+        "typeName";
+
+      if (!typeName || typeName === "null" || typeName === "") {
+        // Try to use element name as fallback
+        if (element.name && element.name !== "null" && element.name !== "") {
+          typeName = element.name;
+          nameSource = "instanceName";
+        }
+        // If name also missing, try to use element type
+        else if (
+          element.type &&
+          element.type !== "null" &&
+          element.type !== ""
+        ) {
+          typeName = element.type;
+          nameSource = "ifcClass";
+        }
+        // Last resort fallback
+        else {
+          typeName = "Unbekannter Typ";
+          nameSource = "unknown";
+        }
+      }
 
       // Initialize the entry for this typeName if it doesn't exist
       if (!summaryMap[typeName]) {
-        summaryMap[typeName] = { totalCount: 0, editedCount: 0 };
+        summaryMap[typeName] = {
+          totalCount: 0,
+          editedCount: 0,
+          nameSource: nameSource,
+        };
       }
 
       // Increment the total count for this typeName
@@ -85,10 +134,11 @@ export const QtoPreviewDialog: React.FC<QtoPreviewDialogProps> = ({
     // Convert the map into an array of TypeSummary objects and sort alphabetically
     return Object.entries(summaryMap)
       .map(
-        ([typeName, counts]): TypeSummary => ({
+        ([typeName, info]): TypeSummary => ({
           typeName,
-          totalCount: counts.totalCount,
-          editedCount: counts.editedCount,
+          nameSource: info.nameSource,
+          totalCount: info.totalCount,
+          editedCount: info.editedCount,
         })
       )
       .sort((a, b) => a.typeName.localeCompare(b.typeName));
@@ -107,42 +157,105 @@ export const QtoPreviewDialog: React.FC<QtoPreviewDialogProps> = ({
       maxWidth="sm" // Adjusted width for the summary view
       fullWidth
     >
-      <DialogTitle id="preview-dialog-title">
-        Zusammenfassung & Senden:
+      <DialogTitle
+        id="preview-dialog-title"
+        sx={{
+          pb: 1,
+          pr: "140px", // Make room for the chips
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Typography variant="h6" component="div" sx={{ fontWeight: "medium" }}>
+          {selectedProject}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" component="div">
+          {selectedFileName}
+        </Typography>
       </DialogTitle>
       <DialogContent>
-        {/* Display overall project/file info and totals */}
-        <DialogContentText
-          component="div"
-          id="preview-dialog-description"
-          sx={{ mb: 2 }}
+        {/* Element count chips at top right */}
+        <Box
+          sx={{
+            position: "absolute",
+            top: "16px",
+            right: "24px",
+            display: "flex",
+            gap: 2,
+          }}
         >
-          <Typography variant="body1" gutterBottom>
-            Bitte vor dem Senden die IFC Elemente überprüfen und bei Bedarf die ermittelten Mengen bearbeiten:
-          </Typography>
-          <Typography variant="body2">
-            Projekt: <strong>{selectedProject}</strong>
-          </Typography>
-          <Typography variant="body2">
-            Datei: <strong>{selectedFileName}</strong>
-          </Typography>
-          <Typography variant="body2">
-            Elemente Gesamt: <strong>{totalElements}</strong>
-          </Typography>
-          <Typography variant="body2" sx={{ mb: 2 }}>
-            Elemente Bearbeitet: <strong>{totalEditedElements}</strong>
-          </Typography>
-        </DialogContentText>
+          <Box sx={{ textAlign: "center" }}>
+            <Chip
+              label={totalElements.toLocaleString()}
+              color="primary"
+              sx={{
+                height: "auto",
+                minWidth: "56px",
+                borderRadius: "20px",
+                "& .MuiChip-label": {
+                  fontSize: "1rem",
+                  fontWeight: "bold",
+                  padding: "4px 8px",
+                  whiteSpace: "nowrap",
+                  overflow: "visible",
+                },
+              }}
+            />
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 0.5, display: "block" }}
+            >
+              Elemente
+            </Typography>
+          </Box>
+
+          <Box sx={{ textAlign: "center" }}>
+            <Chip
+              label={totalEditedElements.toLocaleString()}
+              color={totalEditedElements > 0 ? "secondary" : "default"}
+              sx={{
+                height: "auto",
+                minWidth: "56px",
+                borderRadius: "20px",
+                "& .MuiChip-label": {
+                  fontSize: "1rem",
+                  fontWeight: "bold",
+                  padding: "4px 8px",
+                  whiteSpace: "nowrap",
+                  overflow: "visible",
+                },
+              }}
+            />
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 0.5, display: "block" }}
+            >
+              Bearbeitet
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Brief instruction */}
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mb: 3, fontSize: "0.85rem" }}
+        >
+          Nach dem Senden werden die Elemente für andere Plugins freigegeben.
+        </Typography>
 
         {/* Display the summary table by type */}
         <Typography variant="h6" gutterBottom>
           Übersicht nach Typ
         </Typography>
+
         <TableContainer component={Paper} sx={{ maxHeight: 400 }}>
           <Table stickyHeader size="small" aria-label="summary table">
             <TableHead>
               <TableRow>
-                <TableCell>Typ Name</TableCell>
+                <TableCell>Element Bezeichnung</TableCell>
                 <TableCell align="right">Anzahl Gesamt</TableCell>
                 <TableCell align="right">Anzahl Bearbeitet</TableCell>
               </TableRow>
@@ -164,8 +277,43 @@ export const QtoPreviewDialog: React.FC<QtoPreviewDialogProps> = ({
                       key={summary.typeName} // Use unique typeName for the key
                       sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
                     >
-                      <TableCell component="th" scope="row">
-                        {summary.typeName}
+                      <TableCell
+                        component="th"
+                        scope="row"
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                        }}
+                      >
+                        {/* Only show color indicator if multiple name sources are used */}
+                        {(summaryData.some(
+                          (s) => s.nameSource === "instanceName"
+                        ) ||
+                          summaryData.some(
+                            (s) => s.nameSource === "ifcClass"
+                          )) &&
+                          summary.nameSource !== "unknown" && (
+                            <Box
+                              sx={{
+                                width: 8,
+                                height: 8,
+                                borderRadius: "50%",
+                                bgcolor: TYPE_COLORS[summary.nameSource],
+                                flexShrink: 0,
+                              }}
+                            />
+                          )}
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {summary.typeName}
+                        </Typography>
                       </TableCell>
                       <TableCell align="right">{summary.totalCount}</TableCell>
                       <TableCell align="right">{summary.editedCount}</TableCell>
@@ -176,6 +324,111 @@ export const QtoPreviewDialog: React.FC<QtoPreviewDialogProps> = ({
             </TableBody>
           </Table>
         </TableContainer>
+
+        {/* Only show legend if there are elements AND we have mixed name sources */}
+        {summaryData.length > 0 &&
+          (summaryData.some((s) => s.nameSource === "instanceName") ||
+            summaryData.some((s) => s.nameSource === "ifcClass")) && (
+            <>
+              {/* Determine which types of sources are used */}
+              {(() => {
+                const usedSources = {
+                  typeName: summaryData.some(
+                    (s) => s.nameSource === "typeName"
+                  ),
+                  instanceName: summaryData.some(
+                    (s) => s.nameSource === "instanceName"
+                  ),
+                  ifcClass: summaryData.some(
+                    (s) => s.nameSource === "ifcClass"
+                  ),
+                };
+
+                return (
+                  <Box
+                    sx={{
+                      mt: 1,
+                      mb: 1,
+                      color: "text.secondary",
+                      fontSize: "0.75rem",
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      sx={{ display: "block", mb: 0.5 }}
+                    >
+                      Bei fehlenden Typ-Informationen werden automatisch
+                      Element-Namen oder IFC-Klassen verwendet.
+                    </Typography>
+
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+                      {usedSources.typeName && (
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.8,
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: "50%",
+                              bgcolor: TYPE_COLORS.typeName,
+                            }}
+                          />
+                          <Typography variant="caption">Typ Name</Typography>
+                        </Box>
+                      )}
+
+                      {usedSources.instanceName && (
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.8,
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: "50%",
+                              bgcolor: TYPE_COLORS.instanceName,
+                            }}
+                          />
+                          <Typography variant="caption">
+                            Element Name
+                          </Typography>
+                        </Box>
+                      )}
+
+                      {usedSources.ifcClass && (
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.8,
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: "50%",
+                              bgcolor: TYPE_COLORS.ifcClass,
+                            }}
+                          />
+                          <Typography variant="caption">IFC Klasse</Typography>
+                        </Box>
+                      )}
+                    </Box>
+                  </Box>
+                );
+              })()}
+            </>
+          )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} color="primary">
@@ -187,7 +440,7 @@ export const QtoPreviewDialog: React.FC<QtoPreviewDialogProps> = ({
           disabled={isSending || totalElements === 0} // Disable send if sending or no elements
           autoFocus
         >
-          {isSending ? "Senden..." : "Senden"}
+          {isSending ? "Senden..." : "Bestätigen und Freigeben"}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
- Introduced a new endpoint to approve project elements, updating their status from 'pending' to 'active'.
- Implemented the `approve_project_elements` method in `MongoDBHelper` to handle the approval logic.
- Enhanced `QTOKafkaProducer` to send notifications upon project approval.
- Updated `QTOApiClient` with a method to call the new approval endpoint.
- Modified `MainPage` to integrate project approval functionality, providing user feedback on success or failure.
- Improved `QtoPreviewDialog` to display element counts and types, enhancing user experience during project review.