### PR TITLE
Fix GUID storage in parsed elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Each element in MongoDB is stored with the following structure:
   "project_id": {
     "$oid": "67e39625158688f60bbd807a"
   },
-  "ifc_id": "139",
+  "ifc_id": "3DqaUydM99ehywE4_2hm1u",
   "global_id": "3DqaUydM99ehywE4_2hm1u",
   "ifc_class": "IfcWall",
   "name": "Basic Wall:Holz Aussenwand_470mm:2270026",

--- a/backend/main.py
+++ b/backend/main.py
@@ -395,12 +395,12 @@ def _parse_ifc_data(ifc_file: ifcopenshell.file) -> List[IFCElement]:
         for element in all_elements: # Use all_elements instead of chunking for simplicity here
             try:
                 # Extract basic properties
-                element_id_str = str(element.id())
+                # Use the IFC GUID as the primary identifier
                 element_global_id = element.GlobalId
                 element_type_class = element.is_a()
                 element_instance_name = element.Name if hasattr(element, "Name") and element.Name else "Unnamed"
                 element_data = {
-                    "id": element_id_str,
+                    "id": element_global_id,
                     "global_id": element_global_id,
                     "type": element_type_class,
                     "name": element_instance_name,


### PR DESCRIPTION
## Summary
- use IFC GUID for `ifc_id` when parsing elements
- update README example to match GUID based `ifc_id`

## Testing
- `python3 -m py_compile backend/main.py backend/qto_producer.py`