### PR TITLE
Auto adjust volumes when area edited

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -60,6 +60,7 @@ export interface IFCElement {
     volume?: number;
     unit?: string;
     fraction?: number; // <<< ADD fraction if backend sends it
+    width?: number;
   }>;
   status?: "pending" | "active" | null;
   is_manual?: boolean;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -58,6 +58,7 @@ export interface IFCElement {
         name: string;
         fraction?: number | null | undefined;
         volume?: number | null | undefined;
+        width?: number | null | undefined;
         unit?: string | null | undefined;
       }>
     | null


### PR DESCRIPTION
## Summary
- adjust element and material volumes when user edits area
- expose optional layer width in API and local types
- use new handler for element editing

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684fa9621a5483208a9f3064c1bc2915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When updating the "area" quantity of an element, the app now automatically recalculates and updates the total volume and each material's volume based on the new area value.
  - Materials associated with elements can now display an optional width property if provided.

- **Bug Fixes**
  - Ensured that reverting an invalid or empty area input restores original volume values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->