### PR TITLE
Allow editing quantity type on manual elements

### DIFF
--- a/src/components/IfcElements/ManualElementForm.tsx
+++ b/src/components/IfcElements/ManualElementForm.tsx
@@ -250,8 +250,9 @@ const ManualElementForm: React.FC<ManualElementFormProps> = ({
       setIsQuantityTypeDisabled(true);
       return;
     }
+    // Allow changing the quantity type regardless of the selected element type.
+    setIsQuantityTypeDisabled(false);
     if (selectedType === "ManualQuantity") {
-      setIsQuantityTypeDisabled(false);
       if (
         formData.quantity.type !== "area" &&
         formData.quantity.type !== "length"
@@ -262,7 +263,6 @@ const ManualElementForm: React.FC<ManualElementFormProps> = ({
         }));
       }
     } else {
-      setIsQuantityTypeDisabled(true);
       let determinedKey: "area" | "length" = "area";
       let determinedUnit = "m²";
       if (selectedType.includes("Beam") || selectedType.includes("Column")) {


### PR DESCRIPTION
## Summary
- update ManualElementForm logic so quantity type dropdown is always enabled once a type is chosen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: several modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fac6a3f108320856d6c1613fd6202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form behavior so that quantity type selection is enabled for all element types once a type is selected, instead of being limited to specific types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->