### PR TITLE
Auto-adjust material volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: AGPL](https://img.shields.io/badge/License-AGPL-blue.svg?style=for-the-badge)](https://www.gnu.org/licenses/agpl-3.0)
 [![Version](https://img.shields.io/badge/Version-1.0.0-brightgreen.svg?style=for-the-badge)](https://github.com/LTplus-AG/NHMzh-plugin-qto)
 
-A comprehensive Quantity Take-Off (QTO) module for the Nachhaltigkeitsmonitoring der Stadt Zürich (NHMzh) that extracts, manipulates, and visualizes quantities from IFC models.
+Quantity Take-Off (QTO) module for the Nachhaltigkeitsmonitoring der Stadt Zürich (NHMzh) that extracts, manipulates, and visualizes quantities from IFC models.
 
 ## 📋 Table of Contents
 

--- a/src/components/IfcElements/ElementRow.tsx
+++ b/src/components/IfcElements/ElementRow.tsx
@@ -600,7 +600,11 @@ const ElementRow: React.FC<ElementRowProps> = ({
               <Typography variant="subtitle2" gutterBottom component="div">
                 Materialien
               </Typography>
-              <MaterialsTable element={element} uniqueKey={uniqueKey} />
+              <MaterialsTable
+                element={element}
+                uniqueKey={uniqueKey}
+                editedElement={editedElement}
+              />
             </Box>
           </Collapse>
         </TableCell>

--- a/src/components/IfcElements/MaterialsTable.tsx
+++ b/src/components/IfcElements/MaterialsTable.tsx
@@ -61,7 +61,7 @@ const MaterialsTable: React.FC<MaterialsTableProps> = ({
 
       if (qType === "area") {
         const baseArea = element.original_area ?? element.area;
-        if (materialsVolume !== null && baseArea && typeof newVal === "number") {
+        if (materialsVolume !== null && baseArea && baseArea > 0 && typeof newVal === "number") {
           return materialsVolume * (newVal / baseArea);
         }
       }
@@ -71,6 +71,7 @@ const MaterialsTable: React.FC<MaterialsTableProps> = ({
         if (
           materialsVolume !== null &&
           baseLength &&
+          baseLength > 0 &&
           typeof newVal === "number"
         ) {
           return materialsVolume * (newVal / baseLength);

--- a/src/components/IfcElements/types.ts
+++ b/src/components/IfcElements/types.ts
@@ -8,11 +8,11 @@ export interface EditedQuantity {
 
   originalQuantity?: {
     value: number | null;
-    type: "area" | "length" | "count";
+    type: "area" | "length" | "count" | "volume";
   } | null;
   newQuantity?: {
     value: number | null;
-    type: "area" | "length" | "count";
+    type: "area" | "length" | "count" | "volume";
   } | null;
 }
 


### PR DESCRIPTION
## Summary
- account for edited area or length when displaying material volumes
- pass edit state to MaterialsTable to allow scaling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ca7912fa08320a00812ab340b6a8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Materials tables now dynamically update material volumes based on any locally edited element quantities, including volume adjustments, providing more accurate and responsive information when quantities are changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->