### PR TITLE
Auto scale material volume on manual edits

### DIFF
--- a/src/components/IfcElements/ElementRow.tsx
+++ b/src/components/IfcElements/ElementRow.tsx
@@ -600,7 +600,11 @@ const ElementRow: React.FC<ElementRowProps> = ({
               <Typography variant="subtitle2" gutterBottom component="div">
                 Materialien
               </Typography>
-              <MaterialsTable element={element} uniqueKey={uniqueKey} />
+              <MaterialsTable
+                element={element}
+                uniqueKey={uniqueKey}
+                editedElement={editedElement}
+              />
             </Box>
           </Collapse>
         </TableCell>

--- a/src/components/IfcElements/MaterialsTable.tsx
+++ b/src/components/IfcElements/MaterialsTable.tsx
@@ -11,14 +11,18 @@ import InfoIcon from "@mui/icons-material/Info";
 import { IFCElement } from "../../types/types";
 import { isZeroQuantity, getZeroQuantityStyles } from "../../utils/zeroQuantityHighlight";
 
+import { EditedQuantity } from "./types";
+
 interface MaterialsTableProps {
   element: IFCElement;
   uniqueKey: string;
+  editedElement?: EditedQuantity;
 }
 
 const MaterialsTable: React.FC<MaterialsTableProps> = ({
   element,
   uniqueKey,
+  editedElement,
 }) => {
   // Function to get materials from either materials array or material_volumes object
   const getElementMaterials = (element: IFCElement) => {
@@ -45,7 +49,28 @@ const MaterialsTable: React.FC<MaterialsTableProps> = ({
     return `${(fraction * 100).toFixed(1)}%`;
   };
 
-  const materials = getElementMaterials(element);
+  let materials = getElementMaterials(element);
+
+  // --- Auto adjust material volumes based on edited quantity ---
+  if (
+    editedElement?.newQuantity?.value !== undefined &&
+    editedElement.originalQuantity?.value !== undefined &&
+    typeof editedElement.newQuantity.value === "number" &&
+    typeof editedElement.originalQuantity.value === "number" &&
+    editedElement.originalQuantity.value !== 0 &&
+    editedElement.newQuantity.type === editedElement.originalQuantity.type &&
+    materials.length > 0
+  ) {
+    const ratio = editedElement.newQuantity.value / editedElement.originalQuantity.value;
+    if (isFinite(ratio)) {
+      materials = materials.map((mat) => {
+        if (typeof mat.volume === "number") {
+          return { ...mat, volume: mat.volume * ratio };
+        }
+        return mat;
+      });
+    }
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- auto adjust material volumes when element quantity is edited
- display updated volumes in materials table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ca7912fa08320a00812ab340b6a8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Material volumes in the materials table now automatically update to reflect changes in the element's quantity when edits are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->