### PR TITLE
Fix quantity approval payload global IDs

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -245,14 +245,18 @@ export class QTOApiClient {
   /**
    * Approve project elements AND optionally update quantities
    * @param projectName - The name of the project to approve
-   * @param updates - Optional list of element updates [{ element_id: string, new_quantity: { value: number, type: string, unit: string } }]
+   * @param updates - Optional list of element updates [{ global_id: string, new_quantity: { value: number, type: string, unit?: string | null } }]
    * @returns Response with operation status
    */
   async approveProjectElements(
     projectName: string,
     updates?: Array<{
-      element_id: string;
-      new_quantity: { value?: number | null; type?: string; unit?: string };
+      global_id: string;
+      new_quantity: {
+        value?: number | null;
+        type?: string;
+        unit?: string | null;
+      };
     }>
   ): Promise<{ status: string; message: string; project: string }> {
     const encodedProjectName = encodeURIComponent(projectName);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,11 +1,11 @@
 // Define shared types for the API client
 
 export interface ElementQuantityUpdate {
-  element_id: string;
+  global_id: string;
   new_quantity: {
     value: number | null;
     // Make sure this aligns with backend expectations
     type: "area" | "length" | "volume" | string;
-    unit: string;
+    unit?: string | null;
   };
 }

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -360,7 +360,7 @@ const MainPage = () => {
             // else: Keep default 'area' if type is missing/invalid
 
             quantityUpdates.push({
-              element_id: elementId,
+              global_id: elementId,
               new_quantity: {
                 value: currentQuantity.value ?? null,
                 type: validQuantityType, // Use the determined type
@@ -375,7 +375,7 @@ const MainPage = () => {
             editData.newArea !== null
           ) {
             quantityUpdates.push({
-              element_id: elementId,
+              global_id: elementId,
               new_quantity: {
                 value: editData.newArea,
                 type: "area",
@@ -387,7 +387,7 @@ const MainPage = () => {
             editData.newLength !== null
           ) {
             quantityUpdates.push({
-              element_id: elementId,
+              global_id: elementId,
               new_quantity: {
                 value: editData.newLength,
                 type: "length",


### PR DESCRIPTION
## Summary
- send quantity approval updates using the expected `global_id` field
- allow quantity units to be optional when building approve requests
- ensure the frontend approval payload aligns with the backend ElementQuantityUpdate schema

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6168eedc8320a7e1ed6ef899df3e